### PR TITLE
Fix npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-swagger-ui",
-  "version": "0.2.7.5",
+  "version": "0.2.8",
   "dependencies": {},
   "devDependencies": {
     "glob": "^4.3.5",


### PR DESCRIPTION
Trying to install it via npm, but it does not support `x.x.x.x` versions, only `x.x.x` is the valid format.
